### PR TITLE
feature: let I2CDevice accept frequency as keyword argument

### DIFF
--- a/examples/i2c_read/read16.rb
+++ b/examples/i2c_read/read16.rb
@@ -6,6 +6,6 @@ require 'libmpsse'
 address  = ARGV[0] =~ /^0[xX]/ ? ARGV[0].hex : ARGV[0].to_i
 register = ARGV[1] =~ /^0[xX]/ ? ARGV[1].hex : ARGV[1].to_i
 
-device = LibMpsse::I2CDevice.new(address)
+device = LibMpsse::I2CDevice.new(address: address)
 value = device.read16(register)
 puts format('address: 0x%0.2x: register: 0x%0.4x: 0x%0.4x', address, register, value)

--- a/examples/i2c_read/read8.rb
+++ b/examples/i2c_read/read8.rb
@@ -4,6 +4,6 @@ require 'libmpsse'
 address  = ARGV[0] =~ /^0[xX]/ ? ARGV[0].hex : ARGV[0].to_i
 register = ARGV[1] =~ /^0[xX]/ ? ARGV[1].hex : ARGV[1].to_i
 
-device = LibMpsse::I2CDevice.new(address)
+device = LibMpsse::I2CDevice.new(adress: address)
 value = device.read8(register)
 puts format('address: 0x%0.2x: register: 0x%0.4x: 0x%0.2x', address, register, value)

--- a/lib/libmpsse/i2c_device.rb
+++ b/lib/libmpsse/i2c_device.rb
@@ -14,15 +14,16 @@ module LibMpsse
     ACK = 0
     NACK = 1
 
-    attr_reader :address, :mpsse
+    attr_reader :address, :freq, :mpsse
 
-    def initialize(address)
+    def initialize(address:, freq: ClockRates[:one_hundred_khz])
       @address = address
+      @freq = freq
       @mpsse = new_context
     end
 
     def new_context
-      Mpsse.new(mode: Modes[:i2c])
+      Mpsse.new(mode: Modes[:i2c], freq: @freq, endianess: MSB)
     end
 
     def transaction

--- a/spec/lib/libmpsse/i2c_device_spec.rb
+++ b/spec/lib/libmpsse/i2c_device_spec.rb
@@ -4,7 +4,7 @@ describe LibMpsse::I2CDevice do
   let(:address) { 0x20 }
   let(:address_read) { (address << 1 | 1) }
   let(:address_write) { address << 1 }
-  let(:i2c) { described_class.new(address) }
+  let(:i2c) { described_class.new(address: address) }
   let(:mpsse) { instance_double('mpsse') }
   let(:register_address) { 0x01 }
   let(:register_value_first) { 0xbe }
@@ -20,6 +20,25 @@ describe LibMpsse::I2CDevice do
   describe '#initialize' do
     it 'does not raise' do
       expect { i2c }.not_to raise_error
+    end
+
+    context 'when freq is ommited' do
+      it 'defaults to one_hundred_khz' do
+        expect(i2c.freq).to eq LibMpsse::ClockRates[:one_hundred_khz]
+      end
+    end
+
+    context 'when LibMpsse::ClockRates[:four_hundred_khz] is given' do
+      let(:i2c) do
+        described_class.new(
+          address: address,
+          freq: LibMpsse::ClockRates[:four_hundred_khz]
+        )
+      end
+
+      it 'sets freq to four_hundred_khz' do
+        expect(i2c.freq).to eq LibMpsse::ClockRates[:four_hundred_khz]
+      end
     end
   end
 


### PR DESCRIPTION
defaults to 100 Khz, which is the most widely supported frequency.