### PR TITLE
bugfix: let .read accept register address as 1st arg

### DIFF
--- a/lib/libmpsse/i2c_device.rb
+++ b/lib/libmpsse/i2c_device.rb
@@ -55,10 +55,10 @@ module LibMpsse
     # not been received during the transaction. Repeated start is used before
     # reading register values.
     #
-    # @param [Integer] size in byte to read
     # @param [Integer] register address
+    # @param [Integer] size in byte to read
     # @return [Array<Integer>] array of register values
-    def read(size, register)
+    def read(register, size)
       transaction do
         data = []
         @mpsse.write([address_frame(false), register])
@@ -77,14 +77,14 @@ module LibMpsse
     # @param [Integer] register address
     # @return [Integer] register value
     def read8(register)
-      read(1, register).first
+      read(register, 1).first
     end
 
     # Read two bytes from a 16 bit register
     # @param [Integer] register address
     # @return [Integer] register value
     def read16(register)
-      (first, last) = read(2, register)
+      (first, last) = read(register, 2)
       ((first << 8) & 0xff00) | (last & 0xff)
     end
 

--- a/spec/lib/libmpsse/i2c_device_spec.rb
+++ b/spec/lib/libmpsse/i2c_device_spec.rb
@@ -72,7 +72,7 @@ describe LibMpsse::I2CDevice do
         )
         allow(mpsse).to receive(:send_nacks)
 
-        expect(i2c.read(2, register_address)).to eq [register_value_first, register_value_last]
+        expect(i2c.read(register_address, 2)).to eq [register_value_first, register_value_last]
       end
     end
 
@@ -81,7 +81,7 @@ describe LibMpsse::I2CDevice do
         allow(mpsse).to receive(:write)
         allow(mpsse).to receive(:ack).and_return(LibMpsse::I2CDevice::NACK)
 
-        expect { i2c.read(2, register_address) }.to raise_error LibMpsse::I2CDevice::NoAckReceived
+        expect { i2c.read(register_address, 2) }.to raise_error LibMpsse::I2CDevice::NoAckReceived
       end
     end
   end


### PR DESCRIPTION
.write and .read should use similar argument order (always register
address as 1st argument).